### PR TITLE
feat(ranger): integrate ethp2p

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ relay = { version = "^0.1.0", default-features = false, path = "./relay" }
 # Workaround - these are needed for akula to work as a dependency, since akula
 # itself uses these patches
 [patch.crates-io]
-enr = { git = "https://github.com/rust-ethereum/enr" }
 ethnum = { git = "https://github.com/vorot93/ethnum-rs", branch = "impls" }
 arrayvec = { git = "https://github.com/vorot93/arrayvec", branch = "pop-unchecked" }
 ethp2p-rs = { path = "../ethp2p-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,3 @@ relay = { version = "^0.1.0", default-features = false, path = "./relay" }
 [patch.crates-io]
 ethnum = { git = "https://github.com/vorot93/ethnum-rs", branch = "impls" }
 arrayvec = { git = "https://github.com/vorot93/arrayvec", branch = "pop-unchecked" }
-ethp2p-rs = { path = "../ethp2p-rs" }
-
-[patch."https://github.com/foundry-rs/foundry"]
-anvil-core = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
-anvil = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
-foundry-config = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,22 @@ relay = { version = "^0.1.0", default-features = false, path = "./relay" }
 # Workaround - these are needed for akula to work as a dependency, since akula
 # itself uses these patches
 [patch.crates-io]
-arrayvec = { git = "https://github.com/vorot93/arrayvec", branch = "pop-unchecked" }
 enr = { git = "https://github.com/rust-ethereum/enr" }
 ethnum = { git = "https://github.com/vorot93/ethnum-rs", branch = "impls" }
+arrayvec = { git = "https://github.com/vorot93/arrayvec", branch = "pop-unchecked" }
+ethp2p-rs = { path = "../ethp2p-rs" }
+fastrlp = { git = "https://github.com/rjected/fastrlp", branch = "implement-ethereum-types", features = ["std", "derive", "ethereum-types"] }
+
+[patch."https://github.com/foundry-rs/foundry"]
+anvil-core = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
+anvil = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
+foundry-config = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
+
+[patch."https://github.com/gakonst/ethers-rs"]
+ethers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
+ethers-core = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
+ethers-signers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
+ethers-etherscan = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
+ethers-providers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
+ethers-solc = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp", features = ["async", "svm-solc"] }
+ethers-contract = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,18 +29,8 @@ enr = { git = "https://github.com/rust-ethereum/enr" }
 ethnum = { git = "https://github.com/vorot93/ethnum-rs", branch = "impls" }
 arrayvec = { git = "https://github.com/vorot93/arrayvec", branch = "pop-unchecked" }
 ethp2p-rs = { path = "../ethp2p-rs" }
-fastrlp = { git = "https://github.com/rjected/fastrlp", branch = "implement-ethereum-types", features = ["std", "derive", "ethereum-types"] }
 
 [patch."https://github.com/foundry-rs/foundry"]
 anvil-core = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
 anvil = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
 foundry-config = { git = "https://github.com/rjected/foundry", branch = "fastrlp" }
-
-[patch."https://github.com/gakonst/ethers-rs"]
-ethers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
-ethers-core = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
-ethers-signers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
-ethers-etherscan = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
-ethers-providers = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }
-ethers-solc = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp", features = ["async", "svm-solc"] }
-ethers-contract = { git = "https://github.com/rjected/ethers-rs", branch = "fastrlp" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,7 +41,11 @@ ethereum-types = "0.13"
 fdlimit = "0.2"
 cidr = "0.2.1"
 maplit = "1.0.2"
-secp256k1 = "0.22"
+secp256k1 = { version = "0.23", features = [
+  "global-context",
+  "rand-std",
+  "recovery",
+] }
 
 # for status
 ethp2p-rs = "0.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,9 +13,7 @@ How to use ethers and other tooling to listen to the p2p network
 """
 
 [dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 serde = { version = "1.0.126", features = ["derive"] }
-ranger = { path = "../" }
 
 # TODO: condense extra features needed and determine if necessary, or if they
 # can be upstreamed
@@ -25,30 +23,38 @@ fastrlp = { git = "https://github.com/vorot93/fastrlp" }
 ethereum-forkid = { version = "0.10.0", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 rlp = { version = "0.5.1", default-features = false }
-futures-core = { version = "0.3.21" }
-async-stream = { version = "0.3.2" }
-tokio-stream = { version = "0.1" }
+futures-core = "0.3.21"
+async-stream = "0.3.2"
+tokio-stream = "0.1"
 parking_lot = { version = "0.12.0", default-features = false }
 bytes = { version = "1.1", default-features = false }
 tracing-subscriber = { version = "0.3.11", default-features = false }
-trust-dns-resolver = { version = "0.21" }
+trust-dns-resolver = "0.21"
+
 # determine if necessary
 task-group = { git = "https://github.com/vorot93/task-group" }
-hex = { version = "0.4" }
-clap = { version = "3.1.5" }
-anyhow = { version = "1.0" }
-ethereum-types = { version = "0.13" }
-fdlimit = { version = "0.2" }
-cidr = { version = "0.2.1" }
-maplit = { version = "1.0.2" }
-secp256k1 = { version = "0.23", features = [
-  "global-context",
-  "rand-std",
-  "recovery",
-] }
+hex = "0.4"
+hex-literal = "0.3.4"
+clap = "3.1.5"
+anyhow = "1.0"
+ethereum-types = "0.13"
+fdlimit = "0.2"
+cidr = "0.2.1"
+maplit = "1.0.2"
+secp256k1 = "0.22"
+
+# for status
+ethp2p-rs = "0.1"
+anvil = { git = "http://github.com/foundry-rs/foundry" }
+ethereum-forkid = { version = "0.8.0", default-features = false }
+foundry-config = { git = "http://github.com/foundry-rs/foundry" }
+anvil-core = { git = "https://github.com/foundry-rs/foundry" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
+ruint = { git = "https://github.com/recmo/uint", features = ["fastrlp", "serde"] }
+ranger = { path = "../" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.5" }
+tokio = "1.5"
 
 [[bin]]
 name = "sauron"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,8 +19,8 @@ serde = { version = "1.0.126", features = ["derive"] }
 # can be upstreamed
 tracing = { version = "0.1.29", default-features = false }
 akula = { git = "https://github.com/akula-bft/akula" }
-fastrlp = { git = "https://github.com/vorot93/fastrlp" }
 ethereum-forkid = { version = "0.10.0", default-features = false }
+fastrlp = { version = "0.1.3", features = ["alloc", "derive", "std"] }
 rlp-derive = { version = "0.1.0", default-features = false }
 rlp = { version = "0.5.1", default-features = false }
 futures-core = "0.3.21"
@@ -48,9 +48,8 @@ secp256k1 = { version = "0.23", features = [
 ] }
 
 # for status
-ethp2p-rs = "0.1"
+ethp2p = { git = "https://github.com/rjected/ethp2p" }
 anvil = { git = "http://github.com/foundry-rs/foundry" }
-ethereum-forkid = { version = "0.8.0", default-features = false }
 foundry-config = { git = "http://github.com/foundry-rs/foundry" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }

--- a/cli/sauron.rs
+++ b/cli/sauron.rs
@@ -292,11 +292,11 @@ async fn main() -> anyhow::Result<()> {
             counter = 0;
         }
 
-        if let Some(hash) = hashes_stream.next().await {
+        while let Some(hash) = hashes_stream.next().await {
             info!("New tx hash! {:?}", hex::encode(hash.unwrap()))
         }
 
-        if let Some(new_tx) = tx_stream.next().await {
+        while let Some(new_tx) = tx_stream.next().await {
             info!("New tx! {:?}", new_tx.unwrap())
         }
 

--- a/cli/sauron.rs
+++ b/cli/sauron.rs
@@ -237,91 +237,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tasks = Arc::new(TaskGroup::new());
 
-    let protocol_version = EthProtocolVersion::Eth66;
-
-    // We need to set the status so we can start discovering new peers
-    // Got these from peers, should come up with a way to bootstrap these messages once we're
-    // connected
-    // also the U256 is a re-export of ethereum_types, but we can't use it directly for some reason
-    // let _one_status_message = StatusMessage {
-    //     protocol_version: EthProtocolVersion::Eth66 as usize,
-    //     network_id: 1,
-    //     total_difficulty: akula::models::U256::from_str_radix("36206751599115524359527", 10)
-    //         .unwrap(),
-    //     best_hash: H256::from_str(
-    //         "0xfeb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d",
-    //     )
-    //     .unwrap(),
-    //     genesis_hash: H256::from_str(
-    //         "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-    //     )
-    //     .unwrap(),
-    //     fork_id: ForkId {
-    //         hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-    //         next: 0,
-    //     },
-    // };
-
-    // let two_status_message = StatusMessage {
-    //     protocol_version: EthProtocolVersion::Eth66 as usize,
-    //     network_id: 1,
-    //     total_difficulty: akula::models::U256::from_str_radix("36206751599115524359527", 10)
-    //         .unwrap(),
-    //     best_hash: H256::from_str(
-    //         "0xdeb6f5f89b9592aa8efbf156d7287664cf43f2464d4d7580722dc0b8b80b94ee",
-    //     )
-    //     .unwrap(),
-    //     genesis_hash: H256::from_str(
-    //         "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-    //     )
-    //     .unwrap(),
-    //     fork_id: ForkId {
-    //         hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-    //         next: 0,
-    //     },
-    // };
-
-    // let _another_status_message = StatusMessage {
-    //     protocol_version: EthProtocolVersion::Eth66 as usize,
-    //     network_id: 1,
-    //     total_difficulty: akula::models::U256::from_str_radix("6088371363059432", 10).unwrap(),
-    //     best_hash: H256::from_str(
-    //         "0xce585e7a973311b8db0470a1739ab9eddb38d7edfe3562c5f9eae1d86518d816",
-    //     )
-    //     .unwrap(),
-    //     genesis_hash: H256::from_str(
-    //         "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-    //     )
-    //     .unwrap(),
-    //     fork_id: ForkId {
-    //         hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-    //         next: 0,
-    //     },
-    // };
-
-    // this status message uses a best_hash of the genesis so we don't get asked for headers by
-    // peers.
-    // This is a temporary measure until we can properly relay headers and blocks
-    // let genesis_status = StatusMessage {
-    //     protocol_version: EthProtocolVersion::Eth66 as usize,
-    //     network_id: 1,
-    //     total_difficulty: akula::models::U256::from_str_radix("0", 10).unwrap(),
-    //     best_hash: H256::from_str(
-    //         "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-    //     )
-    //     .unwrap(),
-    //     genesis_hash: H256::from_str(
-    //         "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
-    //     )
-    //     .unwrap(),
-    //     // even though the ForkHash contains hashes that a peer with this status wouldn't know (our
-    //     // best_hash is genesis!), we can still use the most recent forkHash
-    //     fork_id: ForkId {
-    //         hash: ForkHash([0xb7, 0x15, 0x07, 0x7d]),
-    //         next: 0,
-    //     },
-    // };
-
     let status = Status {
         version: EthVersion::Eth67 as u8,
         // ethers versions arent the same due to patches, so using Id here
@@ -336,7 +251,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // tell the relay to use this status message
-    let relay = P2PRelay::new(protocol_version).with_status(status);
+    let relay = P2PRelay::new().with_status(status);
     let relay = Arc::new(relay);
     let no_new_peers = relay.no_new_peers_handle();
 
@@ -353,7 +268,7 @@ async fn main() -> anyhow::Result<()> {
         .with_client_version(format!("sneakyboi/v{}", env!("CARGO_PKG_VERSION")))
         .build(
             btreemap! {
-                CapabilityId { name: capability_name(), version: protocol_version as CapabilityVersion } => 17,
+                CapabilityId { name: capability_name(), version: EthProtocolVersion::Eth66 as CapabilityVersion } => 17,
             },
             relay.clone(),
             secret_key,

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -58,7 +58,16 @@ fastrlp = { version = "0.1.0", features = ["alloc", "derive", "std"] }
 ethereum-forkid = { version = "0.8.0", default-features = false }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 
+# for tower-rlpx
+tower = { version = "0.4", features = ["full"] }
+
 # for a string
 arrayvec = { version = "0.7", features = ["serde"] }
+
+[dev-dependencies]
+# for status
+foundry-config = { git = "http://github.com/foundry-rs/foundry" }
+ruint = { git = "https://github.com/recmo/uint", features = ["fastrlp", "serde"] }
+hex-literal = "0.3.4"
 
 [lib]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -17,8 +17,6 @@ ethers-rs types
 [dependencies]
 serde = { version = "1.0.126", features = ["derive"] }
 
-# TODO: condense extra features needed and determine if necessary, or if they
-# can be upstreamed
 async-trait = "0.1"
 tracing = { version = "0.1.29", default-features = false }
 akula = { git = "https://github.com/akula-bft/akula" }
@@ -55,7 +53,6 @@ ethp2p = { git = "https://github.com/rjected/ethp2p" }
 anvil = { git = "http://github.com/foundry-rs/foundry" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
 fastrlp = { version = "0.1.3", features = ["alloc", "derive", "std"] }
-ethereum-forkid = { version = "0.8.0", default-features = false }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 
 # chain match

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -51,10 +51,10 @@ secp256k1 = { version = "0.23", features = [
 ] }
 
 # for p2p types
-ethp2p-rs = "0.1"
+ethp2p = { git = "https://github.com/rjected/ethp2p" }
 anvil = { git = "http://github.com/foundry-rs/foundry" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
-fastrlp = { version = "0.1.0", features = ["alloc", "derive", "std"] }
+fastrlp = { version = "0.1.3", features = ["alloc", "derive", "std"] }
 ethereum-forkid = { version = "0.8.0", default-features = false }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -15,17 +15,12 @@ ethers-rs types
 """
 
 [dependencies]
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 serde = { version = "1.0.126", features = ["derive"] }
 
 # TODO: condense extra features needed and determine if necessary, or if they
 # can be upstreamed
 async-trait = "0.1"
 tracing = { version = "0.1.29", default-features = false }
-fastrlp = { git = "https://github.com/vorot93/fastrlp", features = [
-    "derive",
-] }
-anvil = { git = "http://github.com/foundry-rs/foundry" }
 akula = { git = "https://github.com/akula-bft/akula" }
 ethereum-forkid = { version = "0.10.0", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
@@ -54,5 +49,16 @@ secp256k1 = { version = "0.23", features = [
   "rand-std",
   "recovery",
 ] }
+
+# for p2p types
+ethp2p-rs = "0.1"
+anvil = { git = "http://github.com/foundry-rs/foundry" }
+anvil-core = { git = "https://github.com/foundry-rs/foundry" }
+fastrlp = { version = "0.1.0", features = ["alloc", "derive", "std"] }
+ethereum-forkid = { version = "0.8.0", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
+
+# for a string
+arrayvec = { version = "0.7", features = ["serde"] }
 
 [lib]

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -58,6 +58,9 @@ fastrlp = { version = "0.1.0", features = ["alloc", "derive", "std"] }
 ethereum-forkid = { version = "0.8.0", default-features = false }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 
+# chain match
+foundry-config = { git = "http://github.com/foundry-rs/foundry" }
+
 # for tower-rlpx
 tower = { version = "0.4", features = ["full"] }
 

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -1,8 +1,10 @@
 mod relay;
-pub use crate::relay::P2PRelay;
+pub use crate::relay::{P2PRelay, P2PRelayError};
 
 mod p2p_api;
 pub use crate::p2p_api::MempoolListener;
 
 mod middleware;
 pub use crate::middleware::P2PMiddleware;
+
+mod service;

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -8,3 +8,6 @@ mod middleware;
 pub use crate::middleware::P2PMiddleware;
 
 mod service;
+
+mod peer_chains;
+pub use crate::peer_chains::PeerChains;

--- a/relay/src/p2p_api.rs
+++ b/relay/src/p2p_api.rs
@@ -1,6 +1,6 @@
 use anvil_core::eth::{block::Block, transaction::TypedTransaction};
 use async_trait::async_trait;
-use ethp2p_rs::EthMessage;
+use ethp2p::EthMessage;
 use futures_core::Stream;
 use std::{collections::HashSet, error::Error, fmt::Debug, hash::Hash};
 use tokio::sync::broadcast::{self, error::SendError, Sender};

--- a/relay/src/p2p_api.rs
+++ b/relay/src/p2p_api.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ethp2p_rs::EthMessage;
 use futures_core::Stream;
 use std::{
     collections::HashSet,
@@ -28,6 +29,13 @@ pub trait MempoolListener: Sync + Send {
 
     /// Subscribe to incoming blocks
     fn subscribe_blocks(&self) -> Result<Self::BlockStream, Self::Error>;
+}
+
+/// Represents an eth protocol message and an associated peer
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeerMessage {
+    pub peer: [u8; 32],
+    pub message: EthMessage,
 }
 
 /// Provides a deduplicating container for transactions

--- a/relay/src/p2p_api.rs
+++ b/relay/src/p2p_api.rs
@@ -1,14 +1,9 @@
+use anvil_core::eth::{block::Block, transaction::TypedTransaction};
 use async_trait::async_trait;
 use ethp2p_rs::EthMessage;
 use futures_core::Stream;
-use std::{
-    collections::HashSet,
-    error::Error,
-    fmt::Debug,
-    hash::Hash,
-};
+use std::{collections::HashSet, error::Error, fmt::Debug, hash::Hash};
 use tokio::sync::broadcast::{self, error::SendError, Sender};
-use anvil_core::eth::{transaction::TypedTransaction, block::Block};
 
 /// Provides a stream based interface for listening to pending transactions
 #[async_trait]

--- a/relay/src/peer_chains.rs
+++ b/relay/src/peer_chains.rs
@@ -1,0 +1,52 @@
+use std::collections::{hash_map::Entry, HashMap, HashSet};
+
+use akula::p2p::node::PeerId;
+use foundry_config::Chain;
+
+/// Data structure which maps a peer to its chain, and the chain to the set of peers on that chain.
+#[derive(Debug, Clone, Default)]
+pub struct PeerChains {
+    /// Map of a peer to a chain.
+    pub peer_chains: HashMap<PeerId, Chain>,
+    /// Map of a chain to a set of peers on that chain.
+    pub chain_peers: HashMap<Chain, HashSet<PeerId>>,
+}
+
+impl PeerChains {
+    /// Add a peer to a chain.
+    pub fn add_peer(&mut self, peer: PeerId, chain: Chain) {
+        self.peer_chains.insert(peer, chain);
+        self.chain_peers
+            .entry(chain)
+            .or_insert_with(HashSet::new)
+            .insert(peer);
+    }
+
+    /// Remove a peer from a chain.
+    pub fn remove_peer(&mut self, peer: PeerId) {
+        if let Some(chain) = self.peer_chains.get(&peer) {
+            if let Entry::Occupied(mut entry) = self.chain_peers.entry(*chain) {
+                entry.get_mut().remove(&peer);
+                if entry.get().is_empty() {
+                    entry.remove();
+                }
+            }
+        }
+        self.peer_chains.remove(&peer);
+    }
+
+    /// Get the chain of a peer.
+    pub fn get_chain(&self, peer: &PeerId) -> Option<&Chain> {
+        self.peer_chains.get(peer)
+    }
+
+    /// Get the list of peers on a chain.
+    pub fn get_peers(&self, chain: &Chain) -> Option<&HashSet<PeerId>> {
+        self.chain_peers.get(chain)
+    }
+
+    /// Determine if a peer is on a chain.
+    pub fn is_on_chain(&self, peer: &PeerId, chain: &Chain) -> bool {
+        self.peer_chains.get(peer) == Some(chain)
+    }
+}

--- a/relay/src/relay.rs
+++ b/relay/src/relay.rs
@@ -599,6 +599,8 @@ impl CapabilityServer for P2PRelay {
                     }
                 };
 
+                debug!("Received rlp message with type {:?} from {:?}: {}", message_type, peer, hex::encode(data.clone()));
+
                 let protocol_message =
                     ProtocolMessage::decode_message(message_type, &mut &data[..]).unwrap_or_else(
                         |err| {

--- a/relay/src/relay.rs
+++ b/relay/src/relay.rs
@@ -10,7 +10,7 @@ use anvil_core::eth::{block::Block, transaction::TypedTransaction};
 use arrayvec::{ArrayString, CapacityError};
 use async_trait::async_trait;
 use ethers::core::types::{ParseChainError, H512};
-use ethp2p_rs::{
+use ethp2p::{
     EthMessage, EthMessageID, GetPooledTransactions, ProtocolMessage, RequestPair, Status,
 };
 use fastrlp::Encodable;

--- a/relay/src/service.rs
+++ b/relay/src/service.rs
@@ -1,5 +1,5 @@
 use crate::{P2PRelay, P2PRelayError};
-use ethp2p_rs::EthMessage;
+use ethp2p::EthMessage;
 use std::{
     future::Future,
     pin::Pin,

--- a/relay/src/service.rs
+++ b/relay/src/service.rs
@@ -1,0 +1,48 @@
+use crate::{P2PRelay, P2PRelayError};
+use tower::Service;
+use ethp2p_rs::EthMessage;
+use tracing::debug;
+use std::{
+    future::Future,
+    sync::Arc,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+impl Service<EthMessage> for P2PRelay {
+    /// The Response is an Option<EthMessage> because peers can return either a response to a
+    /// request, or the message received is a broadcast message which does not require a response.
+    type Response = Option<EthMessage>;
+    type Error = P2PRelayError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: EthMessage) -> Self::Future {
+        let status_map = Arc::clone(&self.status_map);
+        Box::pin(async move {
+            let response = match req {
+                // respond to status messages by default
+                EthMessage::Status(their_status) => {
+                    debug!("Decoded status message from peer: {:?}", their_status);
+                    let mut unlocked_status = status_map.write();
+
+                    // if we can't find the other peer's status, add it to the map so we can send
+                    // it to peers later
+                    match unlocked_status.get(&u64::from(their_status.chain)) {
+                        Some(&status) => Ok(Some(status.into())),
+                        None => {
+                            unlocked_status.insert(u64::from(their_status.chain), their_status);
+                            Ok(Some(their_status.into()))
+                        }
+                    }
+                }
+                _ => Ok(None),
+            };
+            response
+        })
+    }
+}

--- a/relay/src/service.rs
+++ b/relay/src/service.rs
@@ -1,13 +1,13 @@
 use crate::{P2PRelay, P2PRelayError};
-use tower::Service;
 use ethp2p_rs::EthMessage;
-use tracing::debug;
 use std::{
     future::Future,
-    sync::Arc,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
+use tower::Service;
+use tracing::debug;
 
 impl Service<EthMessage> for P2PRelay {
     /// The Response is an Option<EthMessage> because peers can return either a response to a


### PR DESCRIPTION
This should integrate [`ethp2p`](https://github.com/rjected/ethp2p) as the main types we decode to when receiving protocol messages.

Relaying is also improved, peers are tracked along with their chain so ranger can now relay on multiple networks simultaneously.

TODO:
 - [x] Update dependencies
 - [x] Remove `foundry` patches. They are no longer needed due to upstreaming efforts!
 - [x] Either test out or remove the tower service.
 - [x] `s/ethp2p-rs|ethp2p_rs/ethp2p/g`
 - [x] Fix merge conflicts