### PR TITLE
feat(ranger): use Hardfork forkid for status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ members = [
 
 [dependencies]
 relay = { version = "^0.1.0", default-features = false, path = "./relay" }
+
+# temp
+[patch.crates-io]
+revm = { git = "https://github.com/onbjerg/revm", branch = "onbjerg/bytecode-hash" }

--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ Ranger is separated into two parts currently:
      network, and traits for exposing mempool transactions as a `Stream`.
 
 ## Related projects
+ * [ethp2p](https://github.com/rjected/ethp2p), a library built for ranger, which is used for encoding and decoding [`eth`](https://github.com/ethereum/devp2p) messages.
  * [Sentry](https://github.com/akula-bft/akula/tree/master/src/sentry), which provides much of the code that we use to interact with eth p2p networking protocols.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,6 +38,7 @@ secp256k1 = { version = "0.24", features = [
 ethp2p = { git = "https://github.com/rjected/ethp2p" }
 foundry-config = { git = "http://github.com/foundry-rs/foundry" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
+anvil = { git = "https://github.com/foundry-rs/foundry" }
 ruint = { version = "1.3.0", features = ["fastrlp", "serde"] }
 ranger = { path = "../" }
 

--- a/relay/src/p2p_api.rs
+++ b/relay/src/p2p_api.rs
@@ -21,9 +21,6 @@ pub trait MempoolListener: Sync + Send {
 
     /// Subscribe to the incoming pending transaction hashes
     fn subscribe_pending_hashes(&self) -> Result<Self::TxHashStream, Self::Error>;
-
-    /// Subscribe to incoming blocks
-    fn subscribe_blocks(&self) -> Result<Self::BlockStream, Self::Error>;
 }
 
 /// Represents an eth protocol message and an associated peer


### PR DESCRIPTION
This updates the hardcoded status to include the newest hardfork. This should eventually be actively updated or set to a lower value (like `Hardfork::ArrowGlacier`), since a `next` value of zero would cause peers to disconnect after the next fork.

Fixes #12 