### PR TITLE
chore: make clippy happy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,3 @@ members = [
 
 [dependencies]
 relay = { version = "^0.1.0", default-features = false, path = "./relay" }
-
-# temp
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm" }

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -30,7 +30,7 @@ devp2p-rs = { git = "https://github.com/rjected/devp2p-rs" }
 ethereum-forkid = { version = "0.11.0", default-features = false }
 ethp2p = { git = "https://github.com/rjected/ethp2p" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
-fastrlp = { version = "0.1.3", features = ["alloc", "derive", "std"] }
+open-fastrlp = { version = "0.1.4", features = ["alloc", "derive", "std"] }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen", "legacy", "ws"] }
 foundry-config = { git = "http://github.com/foundry-rs/foundry" }
 # for the capability name

--- a/relay/src/relay.rs
+++ b/relay/src/relay.rs
@@ -13,8 +13,8 @@ use ethers::core::types::{ParseChainError, H512};
 use ethp2p::{
     EthMessage, EthMessageID, GetPooledTransactions, ProtocolMessage, RequestPair, Status,
 };
-use fastrlp::Encodable;
 use foundry_config::Chain;
+use open_fastrlp::Encodable;
 use parking_lot::RwLock;
 use std::{
     collections::{HashMap, HashSet},

--- a/relay/src/relay.rs
+++ b/relay/src/relay.rs
@@ -607,7 +607,9 @@ impl CapabilityServer for P2PRelay {
                 if data.len() > MESSAGE_SIZE_LIMIT {
                     debug!(
                         "Received message from {} with size {}. Message size is limited to {}.",
-                        peer, data.len(), MESSAGE_SIZE_LIMIT
+                        peer,
+                        data.len(),
+                        MESSAGE_SIZE_LIMIT
                     );
                     self.disconnect_peer(peer).await;
                     return;


### PR DESCRIPTION
Switches to `open_fastrlp`, and applies lints.